### PR TITLE
update link to supported file types pages

### DIFF
--- a/src/main/html/swagger-all.json
+++ b/src/main/html/swagger-all.json
@@ -1763,7 +1763,7 @@
             "operationId": "upload",
             "parameters": [
                 {
-                    "description": "one or more files, with parameter keys prefixed by `file` (Ex: `file0`, `file1`...). File type must be one of our [supported MIME types](http://developer.sheerid.com/docs/asset-mime-types.html).",
+                    "description": "one or more files, with parameter keys prefixed by `file` (Ex: `file0`, `file1`...). File type must be one of our [supported MIME types](http://developer.sheerid.com/asset-mime-types/).",
                     "in": "formData",
                     "name": "file",
                     "required": false,

--- a/src/main/html/swagger.json
+++ b/src/main/html/swagger.json
@@ -1614,7 +1614,7 @@
             "operationId": "upload",
             "parameters": [
                 {
-                    "description": "one or more files, with parameter keys prefixed by `file` (Ex: `file0`, `file1`...). File type must be one of our [supported MIME types](http://developer.sheerid.com/docs/asset-mime-types.html).",
+                    "description": "one or more files, with parameter keys prefixed by `file` (Ex: `file0`, `file1`...). File type must be one of our [supported MIME types](http://developer.sheerid.com/asset-mime-types/).",
                     "in": "formData",
                     "name": "file",
                     "required": false,


### PR DESCRIPTION
[#141534023] On the Asset upload reference, updated the links from the old list of acceptable file types to the new page hosted on the developer website